### PR TITLE
Fix and normalize governance docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Contributing to `fetch`` <!-- omit from toc -->
+# Contributing to `fetch` <!-- omit from toc -->
 
-First off, thank you for taking the time to contribute to `fetch`! :+1: :tada:
-`fetch` is released under the Apache 2.0 license. If you would like to
-contribute something or want to hack on the code, this document should help you
-get started. You can find some hints for starting development in `fetch`'s
+First off, thank you for taking the time to contribute to fetch! :+1: :tada:
+fetch is released under the Apache 2.0 license. If you would like to contribute
+something or want to hack on the code, this document should help you get
+started. You can find some hints for starting development in fetch's
 [README](https://github.com/StacklokLabs/fetch/blob/main/README.md).
 
 ## Table of contents <!-- omit from toc -->
@@ -14,7 +14,6 @@ get started. You can find some hints for starting development in `fetch`'s
   - [Using GitHub Issues](#using-github-issues)
   - [Not sure how to start contributing?](#not-sure-how-to-start-contributing)
   - [Pull request process](#pull-request-process)
-  - [Contributing to docs](#contributing-to-docs)
   - [Commit message guidelines](#commit-message-guidelines)
 
 ## Code of conduct
@@ -37,8 +36,8 @@ security vulnerabilities using GitHub issues; instead, please follow this
 ### Using GitHub Issues
 
 We use GitHub issues to track bugs and enhancements. If you have a general usage
-question, please ask in
-[fetch's discussion forum](https://discord.gg/stacklok).
+question, please ask in the #mcp-servers channel of the
+[Stacklok Discord server](https://discord.gg/stacklok).
 
 If you are reporting a bug, please help to speed up problem diagnosis by
 providing as much information as possible. Ideally, that would include a small
@@ -51,7 +50,10 @@ PRs to resolve existing issues are greatly appreciated and issues labeled as
 are a great place to start!
 
 ### Pull request process
--All commits must include a Signed-off-by trailer at the end of each commit message to indicate that the contributor agrees to the Developer Certificate of Origin. For additional details, check out the [DCO instructions](dco.md).
+
+-All commits must include a Signed-off-by trailer at the end of each commit
+message to indicate that the contributor agrees to the Developer Certificate of
+Origin. For additional details, check out the [DCO instructions](dco.md).
 
 - Create an issue outlining the fix or feature.
 - Fork the fetch repository to your own GitHub account and clone it locally.
@@ -61,14 +63,9 @@ are a great place to start!
 - Open a PR by ensuring the title and its description reflect the content of the
   PR.
 - Ensure that CI passes, if it fails, fix the failures.
-- Every pull request requires a review from the core fetch team before
-  merging.
+- Every pull request requires a review from the core fetch team before merging.
 - Once approved, all of your commits will be squashed into a single commit with
   your PR title.
-
-### Contributing to docs
-
-TBD
 
 ### Commit message guidelines
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,156 +1,201 @@
-# Security Policy
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-The ToolHive community take security seriously! We appreciate your efforts to
-disclose your findings responsibly and will make every effort to acknowledge
-your contributions.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-## Reporting a vulnerability
+   1. Definitions.
 
-To report a security issue, please use the GitHub Security Advisory
-["Report a Vulnerability"](https://github.com/StacklokLabs/toolhive/security/advisories/new)
-tab.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-If you are unable to access GitHub you can also email us at
-[security@stacklok.com](mailto:security@stacklok.com).
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-Include steps to reproduce the vulnerability, the vulnerable versions, and any
-additional files to reproduce the vulnerability.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-If you are only comfortable sharing under GPG, please start by sending an email
-requesting a public PGP key to use for encryption.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-### Contacting the ToolHive security team
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-Contact the team by sending email to
-[security@stacklok.com](mailto:security@stacklok.com).
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-## Disclosures
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-### Private disclosure processes
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-The ToolHive community asks that all suspected vulnerabilities be handled in
-accordance with
-[Responsible Disclosure model](https://en.wikipedia.org/wiki/Responsible_disclosure).
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-### Public disclosure processes
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-If anyone knows of a publicly disclosed security vulnerability please
-IMMEDIATELY email [security@stacklok.com](mailto:security@stacklok.com) to
-inform us about the vulnerability so that we may start the patch, release, and
-communication process.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-If a reporter contacts the us to express intent to make an issue public before a
-fix is available, we will request if the issue can be handled via a private
-disclosure process. If the reporter denies the request, we will move swiftly
-with the fix and release process.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-## Patch, release, and public communication
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-For each vulnerability, the ToolHive security team will coordinate to create the
-fix and release, and notify the rest of the community.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-All of the timelines below are suggestions and assume a Private Disclosure.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-- The security team drives the schedule using their best judgment based on
-  severity, development time, and release work.
-- If the security team is dealing with a Public Disclosure all timelines become
-  ASAP.
-- If the fix relies on another upstream project's disclosure timeline, that will
-  adjust the process as well.
-- We will work with the upstream project to fit their timeline and best protect
-  ToolHive users.
-- The Security team will give advance notice to the Private Distributors list
-  before the fix is released.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-### Fix team organization
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-These steps should be completed within the first 24 hours of Disclosure.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-- The security team will work quickly to identify relevant engineers from the
-  affected projects and packages and being those engineers into the
-  [security advisory](https://docs.github.com/en/code-security/security-advisories/)
-  thread.
-- These selected developers become the "Fix Team" (the fix team is often drawn
-  from the projects MAINTAINERS)
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-### Fix development process
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-These steps should be completed within the 1-7 days of Disclosure.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-- Create a new
-  [security advisory](https://docs.github.com/en/code-security/security-advisories/)
-  in affected repository by visiting
-  `https://github.com/StacklokLabs/toolhive/security/advisories/new`
-- As many details as possible should be entered such as versions affected, CVE
-  (if available yet). As more information is discovered, edit and update the
-  advisory accordingly.
-- Use the CVSS calculator to score a severity level.
-  ![CVSS Calculator](/images/calc.png)
-- Add collaborators from codeowners team only (outside members can only be added
-  after approval from the security team)
-- The reporter may be added to the issue to assist with review, but **only
-  reporters who have contacted the security team using a private channel**.
-- Select 'Request CVE' ![Request CVE](/docs/static/img/cve.png)
-- The security team / Fix Team create a private temporary fork
-  ![Security Fork](/docs/static/img/fork.png)
-- The Fix team performs all work in a 'security advisory' within its temporary
-  fork
-- CI can be checked locally using the [act](https://github.com/nektos/act)
-  project
-- All communication happens within the security advisory, it is _not_ discussed
-  in slack channels or non private issues.
-- The Fix Team will notify the security team that work on the fix branch is
-  completed, this can be done by tagging names in the advisory
-- The Fix team and the security team will agree on fix release day
-- The recommended release time is 4pm UTC on a non-Friday weekday. This means
-  the announcement will be seen morning Pacific, early evening Europe, and late
-  evening Asia.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-If the CVSS score is under ~4.0
-([a low severity score](https://www.first.org/cvss/specification-document#i5))
-or the assessed risk is low the Fix Team can decide to slow the release process
-down in the face of holidays, developer bandwidth, etc.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-Note: CVSS is convenient but imperfect. Ultimately, the security team has
-discretion on classifying the severity of a vulnerability.
+   END OF TERMS AND CONDITIONS
 
-The severity of the bug and related handling decisions must be discussed on in
-the security advisory, never in public repos.
+   APPENDIX: How to apply the Apache License to your work.
 
-### Fix disclosure process
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-With the Fix Development underway, the security team needs to come up with an
-overall communication plan for the wider community. This Disclosure process
-should begin after the Fix Team has developed a Fix or mitigation so that a
-realistic timeline can be communicated to users.
+   Copyright 2025 Stacklok, Inc.
 
-**Fix release day** (Completed within 1-21 days of Disclosure)
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-- The Fix Team will approve the related pull requests in the private temporary
-  branch of the security advisory
-- The security team will merge the security advisory / temporary fork and its
-  commits into the main branch of the affected repository
-  ![Security Advisory](docs/images/publish.png)
-- The security team will ensure all the binaries are built, signed, publicly
-  available, and functional.
-- The security team will announce the new releases, the CVE number, severity,
-  and impact, and the location of the binaries to get wide distribution and user
-  action. As much as possible this announcement should be actionable, and
-  include any mitigating steps users can take prior to upgrading to a fixed
-  version. An announcement template is available below. The announcement will be
-  sent to the following channels:
-- A link to fix will be posted to the
-  [Stacklok Discord Server](https://discord.gg/stacklok) in the #toolhive
-  channel.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-## Retrospective
-
-These steps should be completed 1-3 days after the Release Date. The
-retrospective process
-[should be blameless](https://landing.google.com/sre/book/chapters/postmortem-culture.html).
-
-- The security team will send a retrospective of the process to the
-  [Stacklok Discord Server](https://discord.gg/stacklok) including details on
-  everyone involved, the timeline of the process, links to relevant PRs that
-  introduced the issue, if relevant, and any critiques of the response and
-  release process.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,13 @@
 # Security Policy
 
-The ToolHive community take security seriously! We appreciate your efforts to
-disclose your findings responsibly and will make every effort to acknowledge
+The StacklokLabs community take security seriously! We appreciate your efforts
+to disclose your findings responsibly and will make every effort to acknowledge
 your contributions.
 
 ## Reporting a vulnerability
 
 To report a security issue, please use the GitHub Security Advisory
-["Report a Vulnerability"](https://github.com/StacklokLabs/toolhive/security/advisories/new)
+["Report a Vulnerability"](https://github.com/StacklokLabs/fetch/security/advisories/new)
 tab.
 
 If you are unable to access GitHub you can also email us at
@@ -19,7 +19,7 @@ additional files to reproduce the vulnerability.
 If you are only comfortable sharing under GPG, please start by sending an email
 requesting a public PGP key to use for encryption.
 
-### Contacting the ToolHive security team
+### Contacting the StacklokLabs security team
 
 Contact the team by sending email to
 [security@stacklok.com](mailto:security@stacklok.com).
@@ -28,7 +28,7 @@ Contact the team by sending email to
 
 ### Private disclosure processes
 
-The ToolHive community asks that all suspected vulnerabilities be handled in
+The StacklokLabs community asks that all suspected vulnerabilities be handled in
 accordance with
 [Responsible Disclosure model](https://en.wikipedia.org/wiki/Responsible_disclosure).
 
@@ -46,8 +46,8 @@ with the fix and release process.
 
 ## Patch, release, and public communication
 
-For each vulnerability, the ToolHive security team will coordinate to create the
-fix and release, and notify the rest of the community.
+For each vulnerability, the StacklokLabs security team will coordinate to create
+the fix and release, and notify the rest of the community.
 
 All of the timelines below are suggestions and assume a Private Disclosure.
 
@@ -58,7 +58,7 @@ All of the timelines below are suggestions and assume a Private Disclosure.
 - If the fix relies on another upstream project's disclosure timeline, that will
   adjust the process as well.
 - We will work with the upstream project to fit their timeline and best protect
-  ToolHive users.
+  StacklokLabs users.
 - The Security team will give advance notice to the Private Distributors list
   before the fix is released.
 
@@ -80,19 +80,17 @@ These steps should be completed within the 1-7 days of Disclosure.
 - Create a new
   [security advisory](https://docs.github.com/en/code-security/security-advisories/)
   in affected repository by visiting
-  `https://github.com/StacklokLabs/toolhive/security/advisories/new`
+  `https://github.com/StacklokLabs/fetch/security/advisories/new`
 - As many details as possible should be entered such as versions affected, CVE
   (if available yet). As more information is discovered, edit and update the
   advisory accordingly.
 - Use the CVSS calculator to score a severity level.
-  ![CVSS Calculator](/images/calc.png)
 - Add collaborators from codeowners team only (outside members can only be added
   after approval from the security team)
 - The reporter may be added to the issue to assist with review, but **only
   reporters who have contacted the security team using a private channel**.
-- Select 'Request CVE' ![Request CVE](/docs/static/img/cve.png)
+- Select 'Request CVE'
 - The security team / Fix Team create a private temporary fork
-  ![Security Fork](/docs/static/img/fork.png)
 - The Fix team performs all work in a 'security advisory' within its temporary
   fork
 - CI can be checked locally using the [act](https://github.com/nektos/act)
@@ -130,7 +128,6 @@ realistic timeline can be communicated to users.
   branch of the security advisory
 - The security team will merge the security advisory / temporary fork and its
   commits into the main branch of the affected repository
-  ![Security Advisory](docs/images/publish.png)
 - The security team will ensure all the binaries are built, signed, publicly
   available, and functional.
 - The security team will announce the new releases, the CVE number, severity,
@@ -140,7 +137,7 @@ realistic timeline can be communicated to users.
   version. An announcement template is available below. The announcement will be
   sent to the following channels:
 - A link to fix will be posted to the
-  [Stacklok Discord Server](https://discord.gg/stacklok) in the #toolhive
+  [Stacklok Discord Server](https://discord.gg/stacklok) in the #mcp-servers
   channel.
 
 ## Retrospective

--- a/dco.md
+++ b/dco.md
@@ -1,17 +1,27 @@
 # Developer Certificate of Origin (DCO)
-In order to contribute to the project, you must agree to the Developer Certificate of Origin. A [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
-is an affirmation that the developer contributing the proposed changes has the necessary rights to submit those changes.
-A DCO provides some additional legal protections while being relatively easy to do. 
+
+In order to contribute to the project, you must agree to the Developer
+Certificate of Origin. A
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/) is an
+affirmation that the developer contributing the proposed changes has the
+necessary rights to submit those changes. A DCO provides some additional legal
+protections while being relatively easy to do.
 
 The entire DCO can be summarized as:
-- Certify that the submitted code can be submitted under the open source license of the project (e.g. Apache 2.0)
-- I understand that what I am contributing is public and will be redistributed indefinitely
 
+- Certify that the submitted code can be submitted under the open source license
+  of the project (e.g. Apache 2.0)
+- I understand that what I am contributing is public and will be redistributed
+  indefinitely
 
 ## How to Use Developer Certificate of Origin
-In order to contribute to the project, you must agree to the Developer Certificate of Origin. To confirm that you agree, your commit message must include a Signed-off-by trailer at the bottom of the commit message. 
+
+In order to contribute to the project, you must agree to the Developer
+Certificate of Origin. To confirm that you agree, your commit message must
+include a Signed-off-by trailer at the bottom of the commit message.
 
 For example, it might look like the following:
+
 ```bash
 A commit message
 
@@ -20,11 +30,19 @@ Closes gh-345
 Signed-off-by: jane marmot <jmarmot@example.org>
 ```
 
-The Signed-off-by [trailer](https://git-scm.com/docs/git-interpret-trailers) can be added automatically by using the [-s or –signoff command line option](https://git-scm.com/docs/git-commit/2.13.7#Documentation/git-commit.txt--s) when specifying your commit message:
+The Signed-off-by [trailer](https://git-scm.com/docs/git-interpret-trailers) can
+be added automatically by using the
+[-s or –signoff command line option](https://git-scm.com/docs/git-commit/2.13.7#Documentation/git-commit.txt--s)
+when specifying your commit message:
+
 ```bash
 git commit -s -m
 ```
-If you have chosen the [Keep my email address private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses) option within GitHub, the Signed-off-by trailer might look something like:
+
+If you have chosen the
+[Keep my email address private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses)
+option within GitHub, the Signed-off-by trailer might look something like:
+
 ```bash
 A commit message
 
@@ -32,4 +50,3 @@ Closes gh-345
 
 Signed-off-by: jane marmot <462403+jmarmot@users.noreply.github.com>
 ```
-


### PR DESCRIPTION
- Fixes the LICENSE file (it mistakenly contained a copy of the security policy)
- Fix project references in the security policy
- Normalizes some formatting with the other repos